### PR TITLE
bugfix broken JSON

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1,4 +1,4 @@
 {
-   "m_descr" : "Dieses Modul wird von vielen anderen Automatisierungs Modulen benötig. Es hat keine eigene Funktionalität, beitet aber viele Hilfsfunktionen für andere Module.\nSiehe https://github.com/maros/Zway-BaseModule//blob/master/README.md für detailliertere Dokumentation.",
+   "m_descr" : "Dieses Modul wird von vielen anderen Automatisierungs Modulen benötig. Es hat keine eigene Funktionalität, beitet aber viele Hilfsfunktionen für andere Module.<br/>Siehe https://github.com/maros/Zway-BaseModule//blob/master/README.md für detailliertere Dokumentation.",
    "m_title" : "Basis Module"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,4 +1,4 @@
 {
-   "m_descr" : "This module is required by many other automation modules. It does not provide any user functionality on its own\nCheck https://github.com/maros/Zway-BaseModule//blob/master/README.md for detailed documentation.",
+   "m_descr" : "This module is required by many other automation modules. It does not provide any user functionality on its own.<br/>Check https://github.com/maros/Zway-BaseModule//blob/master/README.md for detailed documentation.",
    "m_title" : "Base Module"
 }


### PR DESCRIPTION
seems that JSON.parse() couldn't handle '/n' newline

please use instead html tags e.g. also < strong > < ul > < li > could be used to format the description text
